### PR TITLE
Explicitly Depend on Fabric API

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,6 +27,7 @@
 
   "depends": {
     "fabricloader": ">=0.7.4",
+    "fabric": "*",
     "minecraft": "*"
   }
 }


### PR DESCRIPTION
Rich Chat [will crash](https://github.com/Ashley1227/rich-chat/blob/master/src/main/java/io/github/ashley1227/richchat/RichChatMod.java#L7) if Fabric API isn't present, so it should be listed as a dependency